### PR TITLE
Added /clearbones chat command and made some fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,12 @@
+License of source code
+----------------------
+Copyright (C) 2016 ExeterDad
+
+This program is free software; you can redistribute it and/or modify it under the terms
+of the GNU Lesser General Public License as published by the Free Software Foundation;
+either version 2.1 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details:
+https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ around the world, the oldest ones are removed from the world as
 the new one is created. Waypoints are numbered 1 - server limit.
 The newest/latest bones would be 1. Bones waypoints may be hidden
 by using the /showbones chat command again.
+
+If a player wants to clear old waypoints, it can be done using /clearbones chat command.
+It will remove ALL existing bone waypoints for that player.
  
 This mod was created in hopes relieving the frusteration of players and
 admins trying to locate lost bones. There is also the added bonus that 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#Showbones
+# Showbones
 
-###A mod for [Minetest](http://www.minetest.net)
+### A mod for [Minetest](http://www.minetest.net)
 
 This mod saves the locations of player bones in a text file
 "database" in the world directory. Player can use new chat command "/showbones" to

--- a/README.md
+++ b/README.md
@@ -2,30 +2,26 @@
 
 ### A mod for [Minetest](http://www.minetest.net)
 
-This mod saves the locations of player bones in the mod storage database. Players can use the chat command `/showbones` to show waypoints to their bones.
+This mod saves the locations of player bones in the mod storage database. Upon death, the player is shown the location of their bones in the HUD. They can use `/hidebones` to hide the bones HUD, and `/showbones` to show the bones HUD.
 
-If a player has left more than the server limit (default 3) of bones lying around the world, the oldest ones are removed from the world as the new one is created. Waypoints are numbered 1 - server limit. The newest/latest bones would be 1. Bones waypoints may be hidden by using the /showbones chat command again.
+If a player has left more than the server limit (default 3) of bones lying around the world, the oldest ones are removed from the world as the new one is created.
 
 If a player wants to clear old waypoints, it can be done using /clearbones chat command. It will remove ALL existing bone waypoints for that player.
  
 This mod was created in hopes relieving the frustration of players and admins trying to locate lost bones. There is also the added bonus that server admins will no longer need to clean up messy, discarded bones from all around the server. 
 
+## Features
 
-## License: LGPL 2.1
+* Adds chat commands: `/showbones`, `/hidebones`, and `/clearbones`
+* Dependencies: bones
+* Original Forum Post: [Original forum post](https://forum.minetest.net/viewtopic.php?f=9&t=15453)
+
+![screenshot_20160919_212218](https://cloud.githubusercontent.com/assets/9083807/18654745/85df0a5a-7eb1-11e6-8071-3d736b13b435.png)
 
 ## Credits 
 
 * [Justin](https://github.com/JustinLaw64/) modified this mod to where it no longer deletes old bones and provokes owners.
 * PilzAdam - The creator of the bones mod. Some code copied (on_punch function) for a needed override.
 
-## Features
 
-* Adds chat command: /showbones
-* Adds privilege: None at this time
-* Dependencies: bones
-* Original's Post: [Original forum post](https://forum.minetest.net/viewtopic.php?f=9&t=15453)
-* Forum link: [WIP forum post](https://forum.minetest.net/viewtopic.php?f=9&t=15453)
-* Known bugs: Look to the original.
-
-![screenshot_20160919_212218](https://cloud.githubusercontent.com/assets/9083807/18654745/85df0a5a-7eb1-11e6-8071-3d736b13b435.png)
 

--- a/README.md
+++ b/README.md
@@ -1,63 +1,31 @@
-# Showbones
+# showbones-ng
 
 ### A mod for [Minetest](http://www.minetest.net)
 
-This mod saves the locations of player bones in a text file
-"database" in the world directory. Player can use new chat command "/showbones" to
-show waypoints that are visible anywhere in world showing the 
-direction and distance to all recorded bones up to the server
-limit (3 by default). Waypoints are removed and updated as player, or other
-players dig them. If player is online when another player digs
-thier bones, a chat message will appear letting him/her know of
-the crime. :)
+This mod saves the locations of player bones in the mod storage database. Players can use the chat command `/showbones` to show waypoints to their bones.
 
-If a player has left more than the server limit (default 3) of bones lying
-around the world, the oldest ones are removed from the world as
-the new one is created. Waypoints are numbered 1 - server limit.
-The newest/latest bones would be 1. Bones waypoints may be hidden
-by using the /showbones chat command again.
+If a player has left more than the server limit (default 3) of bones lying around the world, the oldest ones are removed from the world as the new one is created. Waypoints are numbered 1 - server limit. The newest/latest bones would be 1. Bones waypoints may be hidden by using the /showbones chat command again.
 
-If a player wants to clear old waypoints, it can be done using /clearbones chat command.
-It will remove ALL existing bone waypoints for that player.
+If a player wants to clear old waypoints, it can be done using /clearbones chat command. It will remove ALL existing bone waypoints for that player.
  
-This mod was created in hopes relieving the frusteration of players and
-admins trying to locate lost bones. There is also the added bonus that 
-server admins will no longer need to clean up messy, discarded bones from
-all around the server. This mod will only track bones lost from the time
-of install. It also will not track bones placed from inventory.
+This mod was created in hopes relieving the frustration of players and admins trying to locate lost bones. There is also the added bonus that server admins will no longer need to clean up messy, discarded bones from all around the server. 
 
-Justin: I modified this mod to where it no longer deletes old bones and provokes owners.
 
-* License: Source code LGPL 2.1
+## License: LGPL 2.1
 
-* Credits: PilzAdam - The creator of the bones mod.
-Some code copied (on_punch function) for a needed override.
+## Credits 
+
+* [Justin](https://github.com/JustinLaw64/) modified this mod to where it no longer deletes old bones and provokes owners.
+* PilzAdam - The creator of the bones mod. Some code copied (on_punch function) for a needed override.
+
+## Features
 
 * Adds chat command: /showbones
-
 * Adds privilege: None at this time
-
 * Dependencies: bones
-
 * Original's Post: [Original forum post](https://forum.minetest.net/viewtopic.php?f=9&t=15453)
-
 * Forum link: [WIP forum post](https://forum.minetest.net/viewtopic.php?f=9&t=15453)
-
 * Known bugs: Look to the original.
 
 ![screenshot_20160919_212218](https://cloud.githubusercontent.com/assets/9083807/18654745/85df0a5a-7eb1-11e6-8071-3d736b13b435.png)
 
-
-
-License of source code
-----------------------
-Copyright (C) 2016 ExeterDad
-
-This program is free software; you can redistribute it and/or modify it under the terms
-of the GNU Lesser General Public License as published by the Free Software Foundation;
-either version 2.1 of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-See the GNU Lesser General Public License for more details:
-https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html

--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,0 @@
-bones
-unified_inventory?

--- a/description.txt
+++ b/description.txt
@@ -1,2 +1,0 @@
-A mod that saves bones positions in a "database".
-Using chatcommand /showbones will reveal visual waypoints of bones locations with distance to simplify recovery.

--- a/init.lua
+++ b/init.lua
@@ -331,6 +331,19 @@ local function is_owner(pos, name) -- need for below bones:bones on_punch overri
 	return false
 end
 minetest.override_item("bones:bones", { -- almost all on_punch copied from bones:bones for override.
+	on_metadata_inventory_take = function(pos, listname, index, stack, player)
+		local meta = minetest.get_meta(pos)
+		if meta:get_inventory():is_empty("main") then
+			local inv = player:get_inventory()
+			if inv:room_for_item("main", {name = "bones:bones"}) then
+				inv:add_item("main", {name = "bones:bones"})
+			else
+				minetest.add_item(pos, "bones:bones")
+			end
+            		showbones.bones_removed(pos, player)
+			minetest.remove_node(pos)
+		end
+	end,
 	on_punch = function(pos, node, player)
 		if(not is_owner(pos, player:get_player_name())) then
 			return

--- a/init.lua
+++ b/init.lua
@@ -4,7 +4,7 @@ if not minetest.global_exists("showbones") then
 	showbones = {
 		modname = "Showbones",
 		showbones_limit = 3,                         -- How many bones a player may have on the server until pruned.
-		datafile = minetest.get_worldpath() .."/showbones.db",
+		datafile = minetest.get_worldpath() .."/mod_storage/showbones.db",
 	}
 end
 

--- a/init.lua
+++ b/init.lua
@@ -304,7 +304,7 @@ minetest.register_on_shutdown(function()
 end)
 minetest.register_on_dieplayer(function(player)
 	local player_name = player:get_player_name()
-	if minetest.setting:get_bool("creative_mode") then -- in creative, no chance of bones, bail
+	if minetest.settings:get_bool("creative_mode") then -- in creative, no chance of bones, bail
 		return
 	end
 	

--- a/init.lua
+++ b/init.lua
@@ -124,6 +124,29 @@ function showbones.hide_hud(player_name) -- removes showbones waypoints and togg
 		showbones_temp[player_name]["togglehud"] = "off"
 	end
 end
+
+-- if someone needs to clear old bone coordinates
+function showbones.clear_bones_data(player_name)
+	local player_table = showbones.get_player_table(player_name)
+	local bones_locations = player_table.bones_locations
+        local count = table.getn(bones_locations)
+		while table.getn(bones_locations) > 0 do
+			local prunepos = bones_locations[count]
+			bones_locations[count] = nil
+			bones_locations = bones_locations
+			prunepos = nil
+			count = count - 1
+		end
+	player_table.bones_locations = bones_locations  -- update with new bones and also pruned
+        showbones.hide_hud(player_name)
+        
+	local message = ""
+	message = "[".. showbones.modname .. "] All bones waypoints are removed."
+    	minetest.chat_send_player(player_name, message)
+
+    	return player_table
+end
+
 function showbones.update_hud(bones_locations, i, player_name) -- Creates one Bones waypoint
 	local pos = bones_locations[i]
 	if not pos then
@@ -201,6 +224,14 @@ minetest.register_chatcommand("showbones", {
 	description = "Show wayoint markers of bones location(s).",
 	func = function(name, param)
 		return showbones.toggle_hud(name)
+	end,
+})
+
+minetest.register_chatcommand("clearbones", { 
+	params = "",
+	description = "Clears ALL wayoint markers of bone location(s).",
+	func = function(name, param)
+		return showbones.clear_bones_data(name)
 	end,
 })
 

--- a/init.lua
+++ b/init.lua
@@ -8,8 +8,8 @@ if not minetest.global_exists("showbones") then
 	}
 end
 
-local share_bones_time = tonumber(minetest.setting_get("share_bones_time")) or 1200
-local share_bones_time_early = tonumber(minetest.setting_get("share_bones_time_early")) or share_bones_time / 4
+local share_bones_time = tonumber(minetest.settings:get("share_bones_time")) or 1200
+local share_bones_time_early = tonumber(minetest.settings:get("share_bones_time_early")) or share_bones_time / 4
 
 
 function showbones.db_load() -- Loads entire showbones database
@@ -304,11 +304,11 @@ minetest.register_on_shutdown(function()
 end)
 minetest.register_on_dieplayer(function(player)
 	local player_name = player:get_player_name()
-	if minetest.setting_getbool("creative_mode") then -- in creative, no chance of bones, bail
+	if minetest.setting:get_bool("creative_mode") then -- in creative, no chance of bones, bail
 		return
 	end
 	
-	local pos = player:getpos()
+	local pos = player:get_pos()
 	pos.x = math.floor(pos.x+0.5)
 	pos.y = math.floor(pos.y+0.5)
 	pos.z = math.floor(pos.z+0.5)

--- a/init.lua
+++ b/init.lua
@@ -381,6 +381,7 @@ minetest.override_item("bones:bones", { -- almost all on_punch copied from bones
 	end,
 })
 
+--[[ remove the button just because Avalon has way too many buttons
 -- Register button that toggles hud.
 if minetest.get_modpath("unified_inventory") then
 	unified_inventory.register_button("showbones", {
@@ -397,3 +398,4 @@ if minetest.get_modpath("unified_inventory") then
 		end,
 	})
 end
+]]

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,7 @@
+name = showbones
+description = """
+A mod that saves bones positions in a "database".
+Using chatcommand /showbones will reveal visual waypoints of bones locations with distance to simplify recovery.
+"""
+depends = bones
+optional_depends = unified_inventory


### PR DESCRIPTION
Added "/cleanbones" chat command which clears ALL waypoints for the user. Also fixed a bug, where waypoint didn't get removed if items were taken from bones one by one without breaking the bones. Fixed deprecated warnings. Added mod.conf, removed depends.txt and description.txt.